### PR TITLE
Fail scaling lambdas on unexpected exceptions

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -27,8 +27,9 @@ def scale_up(event: dict, _context) -> None:
     try:
         event_message = parse_sns_message(event)
         KinesisUpscaler(event_message).scale()
-    except Exception as error:
-        logging.exception(error)
+    except Exception:
+        logging.exception("stream scale-up process failed")
+        raise
 
 
 def scale_down(event: dict, _context) -> None:
@@ -39,5 +40,6 @@ def scale_down(event: dict, _context) -> None:
     try:
         event_message = parse_sns_message(event)
         KinesisDownscaler(event_message).scale()
-    except Exception as error:
-        logging.exception(error)
+    except Exception:
+        logging.exception("stream scale-down process failed")
+        raise

--- a/kinesis_autoscaler/kinesis_autoscaler.py
+++ b/kinesis_autoscaler/kinesis_autoscaler.py
@@ -35,7 +35,6 @@ class KinesisAutoscaler(ABC):
 
         alarm_shard_count = self.parse_alarm_shard_count()
         current_shard_count = self.get_current_shard_count()
-
         if alarm_shard_count != current_shard_count:
             logging.info("Alarm shard count out of sync. Syncing alarms")
             self.update_stream_alarms(current_shard_count)
@@ -44,13 +43,17 @@ class KinesisAutoscaler(ABC):
         target_shard_count = self.get_target_shard_count(current_shard_count)
         if current_shard_count == target_shard_count:
             logging.info(
-                "Current and target shard counts are equal. Autoscaling canceled"
+                "Current and target shard counts are equal. Autoscaling canceled. "
+                f"shard_count={current_shard_count}"
             )
             return
 
         self.update_shard_count(target_shard_count)
         self.update_stream_alarms(target_shard_count)
         self.write_scaling_log_to_db(current_shard_count, target_shard_count)
+        logging.info(
+            f"Scaling process finished successfully. stream={self.stream_name}"
+        )
 
     def parse_stream_name(self) -> str:
         """


### PR DESCRIPTION
By failing the lambdas when unexpected exceptions are raised during the scaling process, we allow the user to monitor the failure and investigate it however he used to (by defining CW alarms / 3rd party monitoring solutions).